### PR TITLE
Edge and CSV parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 ![](https://github.com/jamf/aftermath/blob/main/AftermathLogo.png)
+![](https://img.shields.io/badge/release-1.1.0-bright%20green)&nbsp;![](https://img.shields.io/badge/macOS-12.0%2B-blue)&nbsp;![](https://img.shields.io/badge/license-MIT-orange)
 ## About
 Aftermath is a  Swift-based, open-source incident response framework.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 ![](https://github.com/jamf/aftermath/blob/main/AftermathLogo.png)
+
+<p align="center">
 ![](https://img.shields.io/badge/release-1.1.0-bright%20green)&nbsp;![](https://img.shields.io/badge/macOS-12.0%2B-blue)&nbsp;![](https://img.shields.io/badge/license-MIT-orange)
+</p>
+
 ## About
 Aftermath is a  Swift-based, open-source incident response framework.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 ![](https://github.com/jamf/aftermath/blob/main/AftermathLogo.png)
 
-<p align="center">
+
 ![](https://img.shields.io/badge/release-1.1.0-bright%20green)&nbsp;![](https://img.shields.io/badge/macOS-12.0%2B-blue)&nbsp;![](https://img.shields.io/badge/license-MIT-orange)
-</p>
+
 
 ## About
 Aftermath is a  Swift-based, open-source incident response framework.

--- a/aftermath.xcodeproj/project.pbxproj
+++ b/aftermath.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5E6780F22922E7E800BAF04B /* Edge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6780F12922E7E800BAF04B /* Edge.swift */; };
 		70A44403275707A90035F40E /* SystemReconModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A44402275707A90035F40E /* SystemReconModule.swift */; };
 		70A44405275A76990035F40E /* LSQuarantine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A44404275A76990035F40E /* LSQuarantine.swift */; };
 		70CF9E3A27611C6100FD884B /* ShellHistoryAndProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CF9E3927611C6100FD884B /* ShellHistoryAndProfiles.swift */; };
@@ -33,7 +34,6 @@
 		A0C2E89728AAAE33008FA597 /* ProcLib.h in Sources */ = {isa = PBXBuildFile; fileRef = A029AB2E2877F56E00649701 /* ProcLib.h */; };
 		A0C930CF289852E80011FB87 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = A0C930CE289852E80011FB87 /* ZIPFoundation */; };
 		A0C930D428A4318F0011FB87 /* Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C930D328A4318F0011FB87 /* Timeline.swift */; };
-		A0C930D728A543F80011FB87 /* SwiftCSV in Frameworks */ = {isa = PBXBuildFile; productRef = A0C930D628A543F80011FB87 /* SwiftCSV */; };
 		A0D6D54327F76C58002BB3C8 /* Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D6D54227F76C58002BB3C8 /* Cron.swift */; };
 		A0D6D54727FE147D002BB3C8 /* Overrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D6D54627FE147D002BB3C8 /* Overrides.swift */; };
 		A0D6D54927FE52C1002BB3C8 /* SystemExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D6D54827FE52C1002BB3C8 /* SystemExtensions.swift */; };
@@ -51,7 +51,6 @@
 		A190FFE228B8151F00B9EF9A /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A190FFD528B80C3900B9EF9A /* MockFileManager.swift */; };
 		A190FFE328B8168400B9EF9A /* AftermathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A190FFCF28B8084F00B9EF9A /* AftermathTests.swift */; };
 		A1E433D928B918FF00E2B510 /* Aftermath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABB9E302756D2B500C0ADD7 /* Aftermath.swift */; };
-		A1E433DB28B919A400E2B510 /* SwiftCSV in Frameworks */ = {isa = PBXBuildFile; productRef = A1E433DA28B919A400E2B510 /* SwiftCSV */; };
 		A1E433E528B9270800E2B510 /* dummyPlist.plist in Resources */ = {isa = PBXBuildFile; fileRef = A1E433E428B9270800E2B510 /* dummyPlist.plist */; };
 		A3046F8E27627DAC0069AA21 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3046F8D27627DAC0069AA21 /* Module.swift */; };
 		A3046F902763AE5E0069AA21 /* CaseFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3046F8F2763AE5E0069AA21 /* CaseFiles.swift */; };
@@ -74,6 +73,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5E6780F12922E7E800BAF04B /* Edge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Edge.swift; sourceTree = "<group>"; };
 		70A44402275707A90035F40E /* SystemReconModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemReconModule.swift; sourceTree = "<group>"; };
 		70A44404275A76990035F40E /* LSQuarantine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSQuarantine.swift; sourceTree = "<group>"; };
 		70CF9E3927611C6100FD884B /* ShellHistoryAndProfiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellHistoryAndProfiles.swift; sourceTree = "<group>"; };
@@ -135,7 +135,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A1E433DB28B919A400E2B510 /* SwiftCSV in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -145,7 +144,6 @@
 			files = (
 				A190FFD328B8094600B9EF9A /* XCTest.framework in Frameworks */,
 				A0C930CF289852E80011FB87 /* ZIPFoundation in Frameworks */,
-				A0C930D728A543F80011FB87 /* SwiftCSV in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -263,6 +261,7 @@
 				A0E1E3EA275EC800008D0DC6 /* Firefox.swift */,
 				A0E1E3EC275EC809008D0DC6 /* Chrome.swift */,
 				A0E1E3EE275EC810008D0DC6 /* Safari.swift */,
+				5E6780F12922E7E800BAF04B /* Edge.swift */,
 			);
 			path = browsers;
 			sourceTree = "<group>";
@@ -397,7 +396,6 @@
 			);
 			name = tests;
 			packageProductDependencies = (
-				A1E433DA28B919A400E2B510 /* SwiftCSV */,
 			);
 			productName = aftermathTests;
 			productReference = A190FFDB28B8151300B9EF9A /* tests.xctest */;
@@ -418,7 +416,6 @@
 			name = aftermath;
 			packageProductDependencies = (
 				A0C930CE289852E80011FB87 /* ZIPFoundation */,
-				A0C930D628A543F80011FB87 /* SwiftCSV */,
 			);
 			productName = aftermath;
 			productReference = A3CD4E52274434EE00869ECB /* aftermath */;
@@ -454,7 +451,6 @@
 			mainGroup = A3CD4E49274434EE00869ECB;
 			packageReferences = (
 				A0C930CD289852E80011FB87 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
-				A0C930D528A543F80011FB87 /* XCRemoteSwiftPackageReference "SwiftCSV" */,
 			);
 			productRefGroup = A3CD4E53274434EE00869ECB /* Products */;
 			projectDirPath = "";
@@ -500,6 +496,7 @@
 				A0E22EF2285CD60A003A411A /* CommonDirectories.swift in Sources */,
 				A3046F902763AE5E0069AA21 /* CaseFiles.swift in Sources */,
 				A029AB152876A02800649701 /* ProcessModule.swift in Sources */,
+				5E6780F22922E7E800BAF04B /* Edge.swift in Sources */,
 				A029AB1C28774CA400649701 /* Tree.swift in Sources */,
 				A007835028947E80008489EA /* LoginItems.swift in Sources */,
 				A0C930D428A4318F0011FB87 /* Timeline.swift in Sources */,
@@ -794,14 +791,6 @@
 				minimumVersion = 0.9.9;
 			};
 		};
-		A0C930D528A543F80011FB87 /* XCRemoteSwiftPackageReference "SwiftCSV" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/swiftcsv/SwiftCSV";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.8.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -809,16 +798,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A0C930CD289852E80011FB87 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
 			productName = ZIPFoundation;
-		};
-		A0C930D628A543F80011FB87 /* SwiftCSV */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A0C930D528A543F80011FB87 /* XCRemoteSwiftPackageReference "SwiftCSV" */;
-			productName = SwiftCSV;
-		};
-		A1E433DA28B919A400E2B510 /* SwiftCSV */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A0C930D528A543F80011FB87 /* XCRemoteSwiftPackageReference "SwiftCSV" */;
-			productName = SwiftCSV;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/aftermath.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/aftermath.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "swiftcsv",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftcsv/SwiftCSV",
-      "state" : {
-        "revision" : "048a1d3c2950b9c151ef9364b36f91baadc2c28c",
-        "version" : "0.8.0"
-      }
-    },
-    {
       "identity" : "zipfoundation",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weichsel/ZIPFoundation",

--- a/aftermath/Aftermath.swift
+++ b/aftermath/Aftermath.swift
@@ -6,7 +6,6 @@
 
 
 import Foundation
-import SwiftCSV
 
 class Aftermath {
 
@@ -82,20 +81,6 @@ class Aftermath {
         }
         
     }
-    
-    
-    static func readCSVRows(path: String) -> NamedCSV {
-
-        do {
-            let csvFile = try NamedCSV(url: URL(fileURLWithPath: path), delimiter: .comma, encoding: .utf8)
-            return csvFile
-           
-        } catch {
-            print(error)
-            exit(1)
-        }
-    }
-    
     
     static func sortCSV(unsortedArr: [[String]]) throws -> [[String]] {
         var arr = unsortedArr

--- a/aftermath/Aftermath.swift
+++ b/aftermath/Aftermath.swift
@@ -82,6 +82,7 @@ class Aftermath {
         
     }
     
+    @available(macOS 12.0, *)
     static func sortCSV(unsortedArr: [[String]]) throws -> [[String]] {
         var arr = unsortedArr
         try arr.sort { lhs, rhs in

--- a/aftermath/CaseFiles.swift
+++ b/aftermath/CaseFiles.swift
@@ -16,7 +16,12 @@ struct CaseFiles {
     static let metadataFile = caseDir.appendingPathComponent("metadata.csv")
     static let fm = FileManager.default
     static var serialNumber: String? {
-        let platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
+        var platformExpert: io_service_t = 0
+        if #available(macOS 12.0, *) {
+            platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
+        } else {
+            return nil
+        }
 
         guard platformExpert > 0 else {
             return nil
@@ -26,6 +31,7 @@ struct CaseFiles {
         }
 
         IOObjectRelease(platformExpert)
+       
         return serialNumber
     }
     

--- a/aftermath/CaseFiles.swift
+++ b/aftermath/CaseFiles.swift
@@ -9,29 +9,24 @@ import Foundation
 import ZIPFoundation
 
 struct CaseFiles {
-    var caseeee: String
     static let caseDir = FileManager.default.temporaryDirectory.appendingPathComponent("Aftermath_\(serialNumber ?? Host.current().localizedName?.replacingOccurrences(of: " ", with: "_") ?? "")")
     static let logFile = caseDir.appendingPathComponent("aftermath.log")
     static var analysisCaseDir = FileManager.default.temporaryDirectory
-
     static let analysisLogFile = analysisCaseDir.appendingPathComponent("aftermath_analysis.log")
     static let metadataFile = caseDir.appendingPathComponent("metadata.csv")
     static let fm = FileManager.default
     static var serialNumber: String? {
-        let platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice") )
-      
-      guard platformExpert > 0 else {
-        return nil
-      }
-      
-      guard let serialNumber = (IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformSerialNumberKey as CFString, kCFAllocatorDefault, 0).takeUnretainedValue() as? String)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) else {
-        return nil
-      }
-      
-        
-      IOObjectRelease(platformExpert)
+        let platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
 
-      return serialNumber
+        guard platformExpert > 0 else {
+            return nil
+        }
+        guard let serialNumber = (IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformSerialNumberKey as CFString, kCFAllocatorDefault, 0).takeUnretainedValue() as? String)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) else {
+            return nil
+        }
+
+        IOObjectRelease(platformExpert)
+        return serialNumber
     }
     
     static func CreateCaseDir() {

--- a/aftermath/CaseFiles.swift
+++ b/aftermath/CaseFiles.swift
@@ -9,12 +9,30 @@ import Foundation
 import ZIPFoundation
 
 struct CaseFiles {
-    static let caseDir = FileManager.default.temporaryDirectory.appendingPathComponent("Aftermath_\(Host.current().localizedName ?? "")_\(Date().ISO8601Format().replacingOccurrences(of: ":", with: "_"))")
+    var caseeee: String
+    static let caseDir = FileManager.default.temporaryDirectory.appendingPathComponent("Aftermath_\(serialNumber ?? Host.current().localizedName?.replacingOccurrences(of: " ", with: "_") ?? "")")
     static let logFile = caseDir.appendingPathComponent("aftermath.log")
-    static let analysisCaseDir = FileManager.default.temporaryDirectory.appendingPathComponent("Aftermath_Analysis_\(Host.current().localizedName ?? "")_\(Date().ISO8601Format().replacingOccurrences(of: ":", with: "_"))")
+    static var analysisCaseDir = FileManager.default.temporaryDirectory
+
     static let analysisLogFile = analysisCaseDir.appendingPathComponent("aftermath_analysis.log")
     static let metadataFile = caseDir.appendingPathComponent("metadata.csv")
     static let fm = FileManager.default
+    static var serialNumber: String? {
+        let platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice") )
+      
+      guard platformExpert > 0 else {
+        return nil
+      }
+      
+      guard let serialNumber = (IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformSerialNumberKey as CFString, kCFAllocatorDefault, 0).takeUnretainedValue() as? String)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) else {
+        return nil
+      }
+      
+        
+      IOObjectRelease(platformExpert)
+
+      return serialNumber
+    }
     
     static func CreateCaseDir() {
         do {
@@ -25,7 +43,8 @@ struct CaseFiles {
         }
     }
     
-    static func CreateAnalysisCaseDir() {
+    static func CreateAnalysisCaseDir(filename: String) {
+        self.analysisCaseDir = self.analysisCaseDir.appendingPathComponent("Aftermath_Analysis_\(filename)")
         do {
             try fm.createDirectory(at: analysisCaseDir, withIntermediateDirectories: true, attributes: nil)
             print("Temporary Aftermath Analysis directory created at \(analysisCaseDir.relativePath)")

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -77,11 +77,15 @@ class Command {
          printBanner()
          
          if Self.options.contains(.analyze) {
-             CaseFiles.CreateAnalysisCaseDir()
+             if let name = self.analysisDir?.split(separator: "_").last?.split(separator: ".").first {
+                 CaseFiles.CreateAnalysisCaseDir(filename: String(describing: name))
+             }
+
 
              let mainModule = AftermathModule()
              mainModule.log("Running Aftermath Version \(version)")
              mainModule.log("Aftermath Analysis Started")
+             mainModule.log("Analysis started at \(Date().ISO8601Format().replacingOccurrences(of: ":", with: "_"))")
 
              guard let dir = Self.analysisDir else {
                  mainModule.log("Analysis directory not provided")
@@ -115,6 +119,7 @@ class Command {
              let mainModule = AftermathModule()
              mainModule.log("Running Aftermath Version \(version)")
              mainModule.log("Aftermath Collection Started")
+             mainModule.log("Collection started at \(Date().ISO8601Format().replacingOccurrences(of: ":", with: "_"))")
              mainModule.addTextToFile(atUrl: CaseFiles.metadataFile, text: "file,birth,modified,accessed,permissions,uid,gid, downloadedFrom")
              
 

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -24,7 +24,7 @@ class Command {
     static var analysisDir: String? = nil
     static var outputDir: String = "/tmp"
     static var collectDirs: [String] = []
-    static let version: String = "1.1.0"
+    static let version: String = "1.2.0"
     
     static func main() {
         setup(with: CommandLine.arguments)
@@ -32,6 +32,12 @@ class Command {
     }
 
     static func setup(with fullArgs: [String]) {
+        
+        if NSUserName() != "root" {
+            print("Aftermath must be run as root")
+            print("Exiting...")
+            exit(1)
+        }
 
         let args = [String](fullArgs.dropFirst())
       

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -73,7 +73,7 @@ class Command {
          }
      }
 
-     static func start() {
+    static func start() {
          printBanner()
          
          if Self.options.contains(.analyze) {
@@ -85,7 +85,7 @@ class Command {
              let mainModule = AftermathModule()
              mainModule.log("Running Aftermath Version \(version)")
              mainModule.log("Aftermath Analysis Started")
-             mainModule.log("Analysis started at \(Date().ISO8601Format().replacingOccurrences(of: ":", with: "_"))")
+             mainModule.log("Analysis started at \(mainModule.getCurrentTimeStandardized().replacingOccurrences(of: ":", with: "_"))")
 
              guard let dir = Self.analysisDir else {
                  mainModule.log("Analysis directory not provided")
@@ -99,9 +99,13 @@ class Command {
              let unzippedDir = mainModule.unzipArchive(location: dir)
              
              mainModule.log("Started analysis on Aftermath directory: \(unzippedDir)")
-             let analysisModule = AnalysisModule(collectionDir: unzippedDir)
-             analysisModule.run()
-
+             if #available(macOS 12, *) {
+                 let analysisModule = AnalysisModule(collectionDir: unzippedDir)
+                 analysisModule.run()
+             } else {
+                 // Fallback on earlier versions
+             }
+            
              mainModule.log("Finished analysis module")
              
              guard isDirectoryThatExists(path: Self.outputDir) else {
@@ -119,7 +123,7 @@ class Command {
              let mainModule = AftermathModule()
              mainModule.log("Running Aftermath Version \(version)")
              mainModule.log("Aftermath Collection Started")
-             mainModule.log("Collection started at \(Date().ISO8601Format().replacingOccurrences(of: ":", with: "_"))")
+             mainModule.log("Collection started at \(mainModule.getCurrentTimeStandardized())")
              mainModule.addTextToFile(atUrl: CaseFiles.metadataFile, text: "file,birth,modified,accessed,permissions,uid,gid, downloadedFrom")
              
 
@@ -199,7 +203,7 @@ class Command {
                          try FileManager.default.removeItem(at: dirToRemove)
                          print("Removed \(dirToRemove.relativePath)")
                      } catch {
-                         print("\(Date().ISO8601Format()) - Error removing \(dirToRemove.relativePath)")
+                         print("Error removing \(dirToRemove.relativePath)")
                          print(error)
                      }
                  }

--- a/aftermath/Module.swift
+++ b/aftermath/Module.swift
@@ -107,7 +107,7 @@ class AftermathModule {
         let newFile = dirUrl.appendingPathComponent(filename)
         let path = newFile.relativePath
         if !(FileManager.default.createFile(atPath: path, contents: nil, attributes: nil)) {
-            print("\(Date().ISO8601Format()) - Error creating \(path)")
+            print("\(getCurrentTimeStandardized()) - Error creating \(path)")
         }
         
         return newFile
@@ -131,7 +131,7 @@ class AftermathModule {
     
     func addTextToFileFromUrl(fromFile: URL, toFile: URL) {
         if (!FileManager.default.fileExists(atPath: fromFile.relativePath)) {
-            self.log("\(Date().ISO8601Format())-  Unable to copy text from file \(fromFile.relativePath) as the file does not exist")
+            self.log("\(getCurrentTimeStandardized()) -  Unable to copy text from file \(fromFile.relativePath) as the file does not exist")
             let _ = self.createNewCaseFile(dirUrl: toFile.deletingLastPathComponent(), filename: toFile.lastPathComponent)
             return
         }
@@ -140,13 +140,13 @@ class AftermathModule {
             let contents = try String(contentsOf: fromFile, encoding: .ascii)
             self.addTextToFile(atUrl: toFile, text: "\(fromFile):\n\n\(contents)\n----------\n")
         } catch {
-            self.log("\(Date().ISO8601Format())-  Unable to writing contents of \(fromFile) to \(toFile) due to error:\n\(error) ")
+            self.log("\(getCurrentTimeStandardized())-  Unable to writing contents of \(fromFile) to \(toFile) due to error:\n\(error) ")
         }
     }
     
     func copyFileToCase(fileToCopy: URL, toLocation: URL?, newFileName: String? = nil, isAnalysis: Bool? = false) {
         if (!FileManager.default.fileExists(atPath: fileToCopy.relativePath)) {
-            self.log("\(Date().ISO8601Format()) -  Unable to copy file \(fileToCopy.relativePath) as the file does not exist")
+            self.log("\(getCurrentTimeStandardized()) -  Unable to copy file \(fileToCopy.relativePath) as the file does not exist")
             return
         }
         
@@ -170,7 +170,7 @@ class AftermathModule {
         do {
             try FileManager.default.copyItem(at:fileToCopy, to:dest)
         } catch {
-            self.log("\(Date().ISO8601Format()) - Error copying \(fileToCopy.relativePath) to \(dest)")
+            self.log("\(getCurrentTimeStandardized()) - Error copying \(fileToCopy.relativePath) to \(dest)")
         }
         
     }
@@ -181,7 +181,7 @@ class AftermathModule {
         if fromFile.pathComponents.contains("audit") {
             return
         }
-        
+                
         let helpers = CHelpers()
         var metadata: String
         var birthTimestamp: String
@@ -198,9 +198,12 @@ class AftermathModule {
         if let birth = helpers.getFileBirth(fromFile: fromFile) {
             birthTimestamp = Aftermath.dateFromEpochTimestamp(timeStamp: birth)
             metadata.append("\(birthTimestamp),")
+        
         } else {
             metadata.append("unknwon,")
         }
+        
+        
         
         if let lastModified = helpers.getFileLastModified(fromFile: fromFile) {
             lastModifiedTimestamp = Aftermath.dateFromEpochTimestamp(timeStamp: lastModified)
@@ -257,19 +260,31 @@ class AftermathModule {
     func log(_ note: String, displayOnly: Bool = false, file: String = #file) {
         
         let module = URL(fileURLWithPath: file).lastPathComponent
-        let entry = "\(Date().ISO8601Format()) - \(module) - \(note)"
+        let entry = "\(getCurrentTimeStandardized()) - \(module) - \(note)"
         
         if isPretty {
-            let colorized = "\(Color.magenta.rawValue)\(Date().ISO8601Format())\(Color.colorstop.rawValue) - \(Color.yellow.rawValue)\(module)\(Color.colorstop.rawValue) - \(Color.cyan.rawValue)\(note)\(Color.colorstop.rawValue)"
+            let colorized = "\(Color.magenta.rawValue)\(getCurrentTimeStandardized())\(Color.colorstop.rawValue) - \(Color.yellow.rawValue)\(module)\(Color.colorstop.rawValue) - \(Color.cyan.rawValue)\(note)\(Color.colorstop.rawValue)"
             print(colorized)
         } else {
-            let plainText = "\(Date().ISO8601Format()) - \(module) - \(note)"
+            let plainText = "\(getCurrentTimeStandardized()) - \(module) - \(note)"
             print(plainText)
         }
         
         if displayOnly == false {
             addTextToFile(atUrl: caseLogSelector, text: entry)
         }
+    }
+    
+    func getCurrentTimeStandardized() -> String {
+        let testFormatter = DateFormatter()
+        testFormatter.dateStyle = .full
+        testFormatter.timeStyle = .full
+        testFormatter.locale = Locale(identifier: "en_US_POSIX")
+        testFormatter.dateFormat = "yyyy-MM-dd'T'hh:mm:ss'Z'"
+        
+        let currentDateTime = Date()
+        
+        return testFormatter.string(from: currentDateTime)
     }
     
     func unzipArchive(location: String) -> String {

--- a/analysis/AnalysisModule.swift
+++ b/analysis/AnalysisModule.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(macOS 12, *)
 class AnalysisModule: AftermathModule, AMProto {
     
     let name = "Analysis Module"
@@ -26,7 +27,6 @@ class AnalysisModule: AftermathModule, AMProto {
         self.log("Running analysis on collected aftermath files")
         
         let _ = self.copyFileToCase(fileToCopy: URL(fileURLWithPath: "\(collectionDir)/Recon/system_information.txt"), toLocation: CaseFiles.analysisCaseDir, isAnalysis: true)
-        // ex: timestamp, tcc_update, com.jamf.aftermath, <updates>
        addTextToFile(atUrl: storylineFile, text: "timestamp,type,other,path")
 
         let dbParser = DatabaseParser(collectionDir: collectionDir, storylineFile: storylineFile)

--- a/analysis/DatabaseParser.swift
+++ b/analysis/DatabaseParser.swift
@@ -89,7 +89,7 @@ class DatabaseParser: AftermathModule {
                         }
                         
                         self.addTextToFile(atUrl: tccWriteFile, text: "\(client),\(service),\(authValue),\(authReason),\(last_modified)")
-                        self.addTextToFile(atUrl: storylineFile , text: "\(last_modified),tcc,\(authValue),\(service),\(client)")
+                        self.addTextToFile(atUrl: storylineFile , text: "\(last_modified),tcc_\(authValue),\(service),\(client)")
                     }
                 }
             } else {
@@ -160,7 +160,7 @@ class DatabaseParser: AftermathModule {
                         self.addTextToFile(atUrl: self.quarantineWriteFile, text: "\(LSQuarantineTimeStamp),\(LSQuarantineAgentName),\(LSQuarantineAgentBundleIdentifier),\(LSQuarantineDataURLString),\(LSQuarantineOriginURLString),\(LSQuarantineSenderName),\(LSQuarantineSenderAddress)")
                         
                         if LSQuarantineDataURLString != "" || LSQuarantineOriginURLString != "" {
-                            self.addTextToFile(atUrl: storylineFile, text: "\(LSQuarantineTimeStamp),lsquarantine,\(LSQuarantineAgentName),\(LSQuarantineDataURLString),\(LSQuarantineOriginURLString)")
+                            self.addTextToFile(atUrl: storylineFile, text: "\(LSQuarantineTimeStamp),lsquarantine_\(LSQuarantineAgentName),\(LSQuarantineDataURLString),\(LSQuarantineOriginURLString)")
                         }
                     }
                 }

--- a/analysis/LogParser.swift
+++ b/analysis/LogParser.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(macOS 12, *)
 class LogParser: AftermathModule {
     
     lazy var logsFile = self.createNewCaseFile(dirUrl: CaseFiles.analysisCaseDir, filename: "logs.csv")

--- a/analysis/Storyline.swift
+++ b/analysis/Storyline.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(macOS 12.0, *)
 class Storyline: AftermathModule {
     
     let collectionDir: String
@@ -148,7 +149,7 @@ class Storyline: AftermathModule {
         }
     }
     
-    func readStorylineCSV(path: String) -> [StorylineStruct] {
+    private func readStorylineCSV(path: String) -> [StorylineStruct] {
        
         var storylineStruct = [StorylineStruct]()
         var data = ""

--- a/analysis/Timeline.swift
+++ b/analysis/Timeline.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(macOS 12.0, *)
 class Timeline: AftermathModule {
     
     let collectionDir: String
@@ -96,7 +97,7 @@ class Timeline: AftermathModule {
         }
     }
     
-    func readMetadataCSVRows(path: String) -> [Metadata] {
+    private func readMetadataCSVRows(path: String) -> [Metadata] {
         var metadata = [Metadata]()
         var data = ""
         
@@ -130,7 +131,7 @@ class Timeline: AftermathModule {
         return metadata
     }
     
-    func readTimelineCSVRows(path: String) -> [TimelineStruct] {
+    private func readTimelineCSVRows(path: String) -> [TimelineStruct] {
         
         var timelineStruct = [TimelineStruct]()
         var data = ""

--- a/filesystem/browsers/BrowserModule.swift
+++ b/filesystem/browsers/BrowserModule.swift
@@ -16,6 +16,7 @@ class BrowserModule: AftermathModule, AMProto {
     
     
     func run() {
+        let edgeDir = self.createNewDir(dir: moduleDirRoot, dirname: "Edge")
         let firefoxDir = self.createNewDir(dir: moduleDirRoot, dirname: "Firefox")
         let chromeDir = self.createNewDir(dir: moduleDirRoot, dirname: "Chrome")
         let safariDir = self.createNewDir(dir: moduleDirRoot, dirname: "Safari")
@@ -23,12 +24,14 @@ class BrowserModule: AftermathModule, AMProto {
         
         self.log("Collecting browser information. Make sure browsers are closed to prevent file data from being locked.")
         
+        // Check if Edge is installed
+        let edge = Edge(edgeDir: edgeDir, writeFile: writeFile)
+        edge.run()
         
         // Check if Firefox is installed
         let firefox = Firefox(firefoxDir: firefoxDir, writeFile: writeFile)
         firefox.run()
 
-        
         // Check if Chrome is installed
         let chrome = Chrome(chromeDir: chromeDir, writeFile: writeFile)
         chrome.run()
@@ -36,6 +39,5 @@ class BrowserModule: AftermathModule, AMProto {
         // Check if Safari is installed
         let safari = Safari(safariDir: safariDir, writeFile: writeFile)
         safari.run()
-        
     }
 }

--- a/filesystem/browsers/Chrome.swift
+++ b/filesystem/browsers/Chrome.swift
@@ -115,7 +115,7 @@ class Chrome: BrowserModule {
             }
         }
         
-        self.addTextToFile(atUrl: self.writeFile, text: "\n----- End of Chrome Downlaods -----\n")
+        self.addTextToFile(atUrl: self.writeFile, text: "\n----- End of Chrome Downloads -----\n")
     }
     
     func dumpPreferences() {
@@ -194,7 +194,7 @@ class Chrome: BrowserModule {
     func captureExtensions() {        
         for user in getBasicUsersOnSystem() {
             for profile in getChromeProfilesForUser(user: user) {
-                var chromeExtensionDir = self.createNewDir(dir: self.chromeDir, dirname: "extensions_\(user.username)_\(profile)")
+                let chromeExtensionDir = self.createNewDir(dir: self.chromeDir, dirname: "extensions_\(user.username)_\(profile)")
                 let path = "\(user.homedir)/Library/Application Support/Google/Chrome/\(profile)/Extensions"
             
                 for file in filemanager.filesInDirRecursive(path: path) {

--- a/filesystem/browsers/Edge.swift
+++ b/filesystem/browsers/Edge.swift
@@ -1,0 +1,230 @@
+//
+//  Edge.swift
+//  aftermath
+//
+//  Copyright  2022 JAMF Software, LLC
+//
+
+import Foundation
+import SQLite3
+
+class Edge: BrowserModule {
+        
+    let edgeDir: URL
+    let writeFile: URL
+    
+    init(edgeDir: URL, writeFile: URL) {
+        self.edgeDir = edgeDir
+        self.writeFile = writeFile
+    }
+    
+    func gatherHistory() {
+
+        let historyOutput = self.createNewCaseFile(dirUrl: self.edgeDir, filename: "history_output.csv")
+        self.addTextToFile(atUrl: historyOutput, text: "datetime,user,profile,url")
+        
+        for user in getBasicUsersOnSystem() {
+            for profile in getEdgeProfilesForUser(user: user) {
+
+                // Get the history file for the profile
+                var file: URL
+                if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/History") {
+                    file = URL(fileURLWithPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/History")
+                    self.copyFileToCase(fileToCopy: file, toLocation: self.edgeDir, newFileName: "history_and_downloads\(user.username)_\(profile).db")
+                } else { continue }
+
+                // Open the history file
+                var db: OpaquePointer?
+                if sqlite3_open(file.path, &db) == SQLITE_OK {
+                
+                    // Query the history file
+                    var queryStatement: OpaquePointer? = nil
+                    let queryString = "SELECT datetime(((v.visit_time/1000000)-11644473600), 'unixepoch'), u.url FROM visits v INNER JOIN urls u ON u.id = v.url;"
+
+                    if sqlite3_prepare_v2(db, queryString, -1, &queryStatement, nil) == SQLITE_OK {
+                        var dateTime: String = ""
+                        var url: String = ""
+                        
+                        // write the results to the historyOutput file
+                        while sqlite3_step(queryStatement) == SQLITE_ROW {
+                            if let col1  = sqlite3_column_text(queryStatement, 0) {
+                                let unformattedDatetime = String(cString: col1)
+                                dateTime = Aftermath.standardizeMetadataTimestamp(timeStamp: unformattedDatetime)
+                            }
+                            
+                            let col2 = sqlite3_column_text(queryStatement, 1)
+                            if col2 != nil {
+                                url = String(cString: col2!)
+                            }
+                            
+                            self.addTextToFile(atUrl: historyOutput, text: "\(dateTime),\(user.username),\(profile),\(url)")
+                        }
+                    } else { self.log("Unable to query the database. Please ensure that Edge is not running.") }
+                } else { self.log("Unable to open the database") }
+            }
+        }
+    }
+    
+    func dumpDownloads() {
+        self.addTextToFile(atUrl: self.writeFile, text: "----- Edge Downloads: -----\n")
+        
+        let downlaodsRaw = self.createNewCaseFile(dirUrl: self.edgeDir, filename: "downloads_output.csv")
+        self.addTextToFile(atUrl: downlaodsRaw, text: "datetime,user,profile,url,target_path,danger_type,opened")
+        
+        for user in getBasicUsersOnSystem() {
+            for profile in getEdgeProfilesForUser(user: user) {
+                var file: URL
+                if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/History") {
+                    file = URL(fileURLWithPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/History")
+                } else { continue }
+
+                var db: OpaquePointer?
+                if sqlite3_open(file.path, &db) == SQLITE_OK {
+                    var queryStatement: OpaquePointer? = nil
+                    let queryString = "SELECT datetime(d.start_time/1000000-11644473600, 'unixepoch'), dc.url, d.target_path, d.danger_type, d.opened FROM downloads d INNER JOIN downloads_url_chains dc ON dc.id = d.id;"
+                
+                    if sqlite3_prepare_v2(db, queryString, -1, &queryStatement, nil) == SQLITE_OK {
+                        var dateTime: String = ""
+                        var url: String = ""
+                        var targetPath: String = ""
+                        var dangerType: String = ""
+                        var opened: String = ""
+                        
+                        while sqlite3_step(queryStatement) == SQLITE_ROW {
+                            if let col1  = sqlite3_column_text(queryStatement, 0) {
+                                let unformattedDatetime = String(cString: col1)
+                                dateTime = Aftermath.standardizeMetadataTimestamp(timeStamp: unformattedDatetime)
+                            }
+                            
+                            let col2 = sqlite3_column_text(queryStatement, 1)
+                            if let col2 = col2 { url = String(cString: col2) }
+
+                            let col3 = sqlite3_column_text(queryStatement, 2)
+                            if let col3 = col3 { targetPath = String(cString: col3) }
+                            
+                            let col4 = sqlite3_column_text(queryStatement, 3)
+                            if let col4 = col4 { dangerType = String(cString: col4) }
+                            
+                            let col5 = sqlite3_column_text(queryStatement, 4)
+                            if let col5 = col5 { opened = String(cString: col5) }
+                            
+                            self.addTextToFile(atUrl: downlaodsRaw, text: " \(dateTime),\(user.username),\(profile),\(url),\(targetPath),\(dangerType),\(opened)")
+                        }
+                    }
+                }
+            }
+        }
+        
+        self.addTextToFile(atUrl: self.writeFile, text: "\n----- End of Edge Downloads -----\n")
+    }
+    
+    func dumpPreferences() {
+        for user in getBasicUsersOnSystem() {
+            for profile in getEdgeProfilesForUser(user: user) {
+                var file: URL
+                if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/Preferences") {
+                    file = URL(fileURLWithPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/Preferences")
+                    self.copyFileToCase(fileToCopy: file, toLocation: self.edgeDir, newFileName: "preferenes_\(user.username)_\(profile)")
+                } else { continue }
+                        
+                do {
+                    let data = try Data(contentsOf: file, options: .mappedIfSafe)
+                    if let json = try JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as? [String: Any] {
+                        self.addTextToFile(atUrl: writeFile, text: "\nEdge Preferences -----\n\(String(describing: json))\n ----- End of Edge Preferences -----\n")
+                    }
+                    
+                } catch { self.log("Unable to capture Edge Preferenes") }
+            }
+        }
+    }
+    
+    func dumpCookies() {
+        self.addTextToFile(atUrl: self.writeFile, text: "----- Edge Cookies: -----\n")
+
+        for user in getBasicUsersOnSystem() {
+            for profile in getEdgeProfilesForUser(user: user) {
+                var file: URL
+                if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/Cookies") {
+                    file = URL(fileURLWithPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/Cookies")
+                    self.copyFileToCase(fileToCopy: file, toLocation: self.edgeDir, newFileName: "cookies_\(user.username)_\(profile).db")
+                } else { continue }
+                        
+                var db: OpaquePointer?
+                if sqlite3_open(file.path, &db) == SQLITE_OK {
+                    var queryStatement: OpaquePointer? = nil
+                    let queryString = "select datetime(creation_utc/100000 -11644473600, 'unixepoch'), name,  host_key, path, datetime(expires_utc/100000-11644473600, 'unixepoch') from cookies;"
+                
+                    if sqlite3_prepare_v2(db, queryString, -1, &queryStatement, nil) == SQLITE_OK {
+                        var dateTime: String = ""
+                        var name: String = ""
+                        var hostKey: String = ""
+                        var path: String = ""
+                        var expireTime: String = ""
+                        
+                        while sqlite3_step(queryStatement) == SQLITE_ROW {
+                            if let col1  = sqlite3_column_text(queryStatement, 0) {
+                                dateTime = String(cString: col1)
+                            }
+                            
+                            if let col2 = sqlite3_column_text(queryStatement, 1) {
+                                name = String(cString: col2)
+                            }
+                            
+                            if let col3 = sqlite3_column_text(queryStatement, 2) {
+                                hostKey = String(cString: col3)
+                            }
+                            
+                            if let col4 = sqlite3_column_text(queryStatement, 3) {
+                                path = String(cString: col4)
+                            }
+                            
+                            if let col5 = sqlite3_column_text(queryStatement, 4) {
+                                expireTime = String(cString: col5)
+                            }
+                            
+                            self.addTextToFile(atUrl: self.writeFile, text: "DateTime: \(dateTime)\nUser: \(user.username)\nProfile: \(profile)\nName: \(name)\nHostKey: \(hostKey)\nPath:\(path)\nExpireTime: \(expireTime)\n\n")
+                        }
+                    }
+                }
+            }
+        }
+        self.addTextToFile(atUrl: self.writeFile, text: "\n----- End of Edge Cookies -----\n")
+    }
+    
+    func captureExtensions() {
+        for user in getBasicUsersOnSystem() {
+            for profile in getEdgeProfilesForUser(user: user) {
+                let edgeExtensionDir = self.createNewDir(dir: self.edgeDir, dirname: "extensions_\(user.username)_\(profile)")
+                let path = "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/Extensions"
+            
+                for file in filemanager.filesInDirRecursive(path: path) {
+                    self.copyFileToCase(fileToCopy: file, toLocation: edgeExtensionDir)
+                }
+            }
+            
+        }
+    }
+
+    func getEdgeProfilesForUser(user: User) -> [String] {
+        var profiles: [String] = []
+        // Get the directory name if it contains the string "Profile"
+        if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Microsoft Edge") {
+            for file in filemanager.filesInDir(path: "\(user.homedir)/Library/Application Support/Microsoft Edge") {
+                if file.lastPathComponent.starts(with: "Profile") || file.lastPathComponent == "Default" {
+                    profiles.append(file.lastPathComponent)
+                }
+            }
+        }
+        
+        return profiles
+    }
+    
+    override func run() {
+        self.log("Collecting Edge browser information...")
+        gatherHistory()
+        dumpDownloads()
+        dumpPreferences()
+        dumpCookies()
+        captureExtensions()
+    }
+}

--- a/tests/aftermath/AftermathTests.swift
+++ b/tests/aftermath/AftermathTests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import SwiftCSV
 
 class AftermathTests: XCTestCase {
 


### PR DESCRIPTION
- added support for Edge browser (pretty much identical to Chrome)
- fixed typo in `browsers.txt` file
- instead of using computer name for aftermath directory name, using serial number instead. This is much more consistent. if serial number comes back as null, use the device name
- removed timestamp from file name to remove clutter and added a 'started collection' log line in the `aftermath.log`
- Wrote our own csv parser as the SwiftCSV package was throwing errors and they were unable to be handled gracefully. This change required rewrites to much of the analysis section. This should address Issue #38 
- added macOS 11 compatibility for collection _only_. **Analysis still requires macOS 12 or greater**. Per issue #41 
- updated program entry to exit if not root
- added shields to readme for readability