### PR TITLE
external UL file, xattr, config profiles, hash info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![](https://github.com/jamf/aftermath/blob/main/AftermathLogo.png)
 
 
-![](https://img.shields.io/badge/release-1.3.0-bright%20green)&nbsp;![](https://img.shields.io/badge/macOS-12.0%2B-blue)&nbsp;![](https://img.shields.io/badge/license-MIT-orange)
+![](https://img.shields.io/badge/release-1.2.0-bright%20green)&nbsp;![](https://img.shields.io/badge/macOS-12.0%2B-blue)&nbsp;![](https://img.shields.io/badge/license-MIT-orange)
 
 
 ## About
@@ -57,7 +57,7 @@ sudo ./aftermath --analyze <path_to_collection_zip>
 ```
 
 ### External Unified Log Predicates
-As of v1.3.0, users have the ability to pass Aftermath a text file of unified log predicates using the `--logs` or `-l` arguments. The file being passed to Aftermath is required to be a text file and each predicate needs to be newline-separated. In addition, each line item will be a dictionary object. The key in the dictionary will whatever the user desires to call this predicate. For example, if you want to see all login events, we will create a predicate and title it `login_events`.
+As of v1.2.0, users have the ability to pass Aftermath a text file of unified log predicates using the `--logs` or `-l` arguments. The file being passed to Aftermath is required to be a text file and each predicate needs to be newline-separated. In addition, each line item will be a dictionary object. The key in the dictionary will whatever the user desires to call this predicate. For example, if you want to see all login events, we will create a predicate and title it `login_events`.
 ```
 login_events: processImagePath contains "loginwindow" and eventMessage contains "com.apple.sessionDidLogin
 tcc: process == "tccd"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd <path_to_aftermath_directory>
 ```
 Build using Xcode
 ```bash
-xcodebuild
+xcodebuild -scheme "aftermath"
 ``` 
 `cd` into the Release folder
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![](https://github.com/jamf/aftermath/blob/main/AftermathLogo.png)
 
 
-![](https://img.shields.io/badge/release-1.1.0-bright%20green)&nbsp;![](https://img.shields.io/badge/macOS-12.0%2B-blue)&nbsp;![](https://img.shields.io/badge/license-MIT-orange)
+![](https://img.shields.io/badge/release-1.3.0-bright%20green)&nbsp;![](https://img.shields.io/badge/macOS-12.0%2B-blue)&nbsp;![](https://img.shields.io/badge/license-MIT-orange)
 
 
 ## About
@@ -56,6 +56,13 @@ sudo ./aftermath -o /Users/user/Desktop --deep
 sudo ./aftermath --analyze <path_to_collection_zip>
 ```
 
+### External Unified Log Predicates
+As of v1.3.0, users have the ability to pass Aftermath a text file of unified log predicates using the `--logs` or `-l` arguments. The file being passed to Aftermath is required to be a text file and each predicate needs to be newline-separated. In addition, each line item will be a dictionary object. The key in the dictionary will whatever the user desires to call this predicate. For example, if you want to see all login events, we will create a predicate and title it `login_events`.
+```
+login_events: processImagePath contains "loginwindow" and eventMessage contains "com.apple.sessionDidLogin
+tcc: process == "tccd"
+```
+
 ## Releases
 There is an Aftermath.pkg available under [Releases](https://github.com/jamf/aftermath/releases). This pkg is signed and notarized. It will install the aftermath binary at `/usr/local/bin/`. This would be the ideal way to deploy via MDM. Since this is installed in `bin`, you can then run aftermath like
 ```bash
@@ -74,6 +81,8 @@ To uninstall the aftermath binary, run the `AftermathUninstaller.pkg` from the [
     usage: --collect-dirs <path_to_dir> <path_to_another_dir>
 --deep or -d -> perform a deep scan of the file system for modified and accessed timestamped metadata
     WARNING: This will be a time-intensive, memory-consuming scan.
+--logs -> specify an external text file with unified log predicates (as dictionary objects) to parse
+    usage: --logs /Users/<USER>/Desktop/myPredicates.txt
 -o or --output -> specify an output location for Aftermath collection results (defaults to /tmp)
      usage: -o Users/user/Desktop
 --pretty -> colorize Terminal output

--- a/aftermath.xcodeproj/project.pbxproj
+++ b/aftermath.xcodeproj/project.pbxproj
@@ -715,12 +715,12 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 6PV5YF2UES;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = 6PV5YF2UES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -730,6 +730,7 @@
 				MACH_O_TYPE = mh_execute;
 				NEW_SETTING = "";
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.aftermath;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT) $(SRCROOT)/libs/ProcLib $(SRCROOT)/libs/launchdXPC";
@@ -744,11 +745,11 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 6PV5YF2UES;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = 6PV5YF2UES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -758,7 +759,7 @@
 				MACH_O_TYPE = mh_execute;
 				NEW_SETTING = "";
 				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.crashsecurity.aftermath;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.aftermath;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT) $(SRCROOT)/libs/ProcLib $(SRCROOT)/libs/launchdXPC";

--- a/aftermath.xcodeproj/project.pbxproj
+++ b/aftermath.xcodeproj/project.pbxproj
@@ -7,7 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5E494473293AC914007FFBDD /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E494472293AC914007FFBDD /* URL.swift */; };
+		5E494475293D50FE007FFBDD /* ConfigurationProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E494474293D50FE007FFBDD /* ConfigurationProfiles.swift */; };
 		5E6780F22922E7E800BAF04B /* Edge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6780F12922E7E800BAF04B /* Edge.swift */; };
+		5E93B0AE2941608D009D2AB5 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E93B0AD2941608D009D2AB5 /* Data.swift */; };
+		5E93B0B0294160B6009D2AB5 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E93B0AF294160B6009D2AB5 /* String.swift */; };
 		70A44403275707A90035F40E /* SystemReconModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A44402275707A90035F40E /* SystemReconModule.swift */; };
 		70A44405275A76990035F40E /* LSQuarantine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A44404275A76990035F40E /* LSQuarantine.swift */; };
 		70CF9E3A27611C6100FD884B /* ShellHistoryAndProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CF9E3927611C6100FD884B /* ShellHistoryAndProfiles.swift */; };
@@ -73,7 +77,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5E494472293AC914007FFBDD /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
+		5E494474293D50FE007FFBDD /* ConfigurationProfiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationProfiles.swift; sourceTree = "<group>"; };
 		5E6780F12922E7E800BAF04B /* Edge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Edge.swift; sourceTree = "<group>"; };
+		5E93B0AD2941608D009D2AB5 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		5E93B0AF294160B6009D2AB5 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		70A44402275707A90035F40E /* SystemReconModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemReconModule.swift; sourceTree = "<group>"; };
 		70A44404275A76990035F40E /* LSQuarantine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSQuarantine.swift; sourceTree = "<group>"; };
 		70CF9E3927611C6100FD884B /* ShellHistoryAndProfiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellHistoryAndProfiles.swift; sourceTree = "<group>"; };
@@ -221,6 +229,7 @@
 				70A44404275A76990035F40E /* LSQuarantine.swift */,
 				70CF9E3927611C6100FD884B /* ShellHistoryAndProfiles.swift */,
 				A08342D7284E48FC005E437A /* LogFiles.swift */,
+				5E494474293D50FE007FFBDD /* ConfigurationProfiles.swift */,
 			);
 			path = artifacts;
 			sourceTree = "<group>";
@@ -333,6 +342,9 @@
 			isa = PBXGroup;
 			children = (
 				A374535C2757C1300074B65C /* FileManager.swift */,
+				5E494472293AC914007FFBDD /* URL.swift */,
+				5E93B0AD2941608D009D2AB5 /* Data.swift */,
+				5E93B0AF294160B6009D2AB5 /* String.swift */,
 			);
 			path = extensions;
 			sourceTree = "<group>";
@@ -489,6 +501,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A3CD4E56274434EE00869ECB /* Command.swift in Sources */,
+				5E494475293D50FE007FFBDD /* ConfigurationProfiles.swift in Sources */,
 				A0C2E89728AAAE33008FA597 /* ProcLib.h in Sources */,
 				A3745358275730870074B65C /* LaunchItems.swift in Sources */,
 				A0FAEEFE28B94B2C00AC655F /* LogParser.swift in Sources */,
@@ -505,6 +518,7 @@
 				A0E1E3EB275EC800008D0DC6 /* Firefox.swift in Sources */,
 				8ABB9E312756D2B500C0ADD7 /* Aftermath.swift in Sources */,
 				A0E1E3F8275ED35D008D0DC6 /* NetworkConnections.swift in Sources */,
+				5E93B0B0294160B6009D2AB5 /* String.swift in Sources */,
 				A0E1E3E9275EC736008D0DC6 /* BrowserModule.swift in Sources */,
 				A02509F428ADB1A80030D6A7 /* CHelpers.swift in Sources */,
 				70A44403275707A90035F40E /* SystemReconModule.swift in Sources */,
@@ -518,9 +532,11 @@
 				A0E1E3ED275EC809008D0DC6 /* Chrome.swift in Sources */,
 				A3046F8E27627DAC0069AA21 /* Module.swift in Sources */,
 				8ABB9E2B27568EB700C0ADD7 /* UnifiedLogModule.swift in Sources */,
+				5E93B0AE2941608D009D2AB5 /* Data.swift in Sources */,
 				A0879957275AD2DC00E885BC /* SystemConfig.swift in Sources */,
 				A0FD80F628C7F82400E91584 /* ProcessParser.swift in Sources */,
 				A05BF3BF284FF8CF009E197B /* Slack.swift in Sources */,
+				5E494473293AC914007FFBDD /* URL.swift in Sources */,
 				A007834E28947D71008489EA /* Emond.swift in Sources */,
 				A076742F2755798F00ED7066 /* ArtifactsModule.swift in Sources */,
 				A0759135275985170006766F /* TCC.swift in Sources */,

--- a/aftermath.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/aftermath.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weichsel/ZIPFoundation",
       "state" : {
-        "revision" : "7254c74b49cec2cb81520523ba993c671f71b066",
+        "revision" : "1b662e2e7a091710ad8a963263939984e2ebf527",
         "version" : "0.9.14"
       }
     }

--- a/aftermath/CaseFiles.swift
+++ b/aftermath/CaseFiles.swift
@@ -64,9 +64,18 @@ struct CaseFiles {
         } else {
             localCaseDir = caseDir
         }
+        
         do {
             let endURL = URL(fileURLWithPath: "\(outputDir)/\(localCaseDir.lastPathComponent)")
             let zippedURL = endURL.appendingPathExtension("zip")
+            
+            if FileManager.default.fileExists(atPath: zippedURL.relativePath) {
+                do {
+                    try FileManager.default.removeItem(at: zippedURL)
+                } catch {
+                    print("Unable to save archive. Error: \(error)")
+                }
+            }
             
             try fm.zipItem(at: localCaseDir, to: endURL, shouldKeepParent: true, compressionMethod: .deflate)
             try fm.moveItem(at: endURL, to: zippedURL)

--- a/aftermath/CaseFiles.swift
+++ b/aftermath/CaseFiles.swift
@@ -22,16 +22,16 @@ struct CaseFiles {
         } else {
             return nil
         }
-
+        
         guard platformExpert > 0 else {
             return nil
         }
         guard let serialNumber = (IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformSerialNumberKey as CFString, kCFAllocatorDefault, 0).takeUnretainedValue() as? String)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) else {
             return nil
         }
-
+        
         IOObjectRelease(platformExpert)
-       
+        
         return serialNumber
     }
     
@@ -56,19 +56,19 @@ struct CaseFiles {
     
     static func MoveTemporaryCaseDir(outputLocation: String, isAnalysis: Bool) {
         print("Checking for existence of output location")
-
+        
         let fm = FileManager.default
         let isDir = fm.isDirectoryThatExists(path: outputLocation)
         guard isDir || fm.fileExists(atPath: outputLocation) else {
             print("Output path is not a valid file or directory that exists")
             return
         }
-
+        
         print("Moving the aftermath directory from its temporary location. This may take some time. Please wait...")
-
+        
         // Determine if we should look in /tmp or in the Aftermath case directory within /tmp
         let localCaseDir = isAnalysis ? analysisCaseDir : caseDir
-
+        
         let endPath: String
         if isDir {
             endPath = "\(outputLocation)/\(localCaseDir.lastPathComponent)"
@@ -76,7 +76,7 @@ struct CaseFiles {
             // Ensure that we end up with the correct (.zip) path extension
             endPath = fm.deletingPathExtension(path: outputLocation)
         }
-
+        
         // The zipped case directory should end up in the specified output location
         do {
             let endURL = URL(fileURLWithPath: endPath)
@@ -89,14 +89,15 @@ struct CaseFiles {
                     print("Unable to save archive. Error: \(error)")
                 }
             }
-
-        do {
-            try fm.zipItem(at: localCaseDir, to: endURL, shouldKeepParent: true, compressionMethod: .deflate)
-            try fm.moveItem(at: endURL, to: zippedURL)
-            print("Aftermath archive moved to \(zippedURL.path)")
-    
-        } catch {
-            print("Unable to create archive. Error: \(error)")
+            
+            do {
+                try fm.zipItem(at: localCaseDir, to: endURL, shouldKeepParent: true, compressionMethod: .deflate)
+                try fm.moveItem(at: endURL, to: zippedURL)
+                print("Aftermath archive moved to \(zippedURL.path)")
+                
+            } catch {
+                print("Unable to create archive. Error: \(error)")
+            }
         }
     }
 }

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -26,7 +26,7 @@ class Command {
     static var outputLocation: String = "/tmp"
     static var collectDirs: [String] = []
     static var unifiedLogsFile: String? = nil
-    static let version: String = "1.2.0"
+    static let version: String = "1.2.1"
     
     static func main() {
         setup(with: CommandLine.arguments)

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -15,6 +15,7 @@
      static let analyze = Options(rawValue: 1 << 2)
      static let pretty = Options(rawValue: 1 << 3)
      static let collectDirs = Options(rawValue: 1 << 4)
+     static let unifiedLogs = Options(rawValue: 1 << 5)
      
  }
 
@@ -24,6 +25,7 @@ class Command {
     static var analysisDir: String? = nil
     static var outputDir: String = "/tmp"
     static var collectDirs: [String] = []
+    static var unifiedLogsFile: String? = nil
     static let version: String = "1.2.0"
     
     static func main() {
@@ -65,6 +67,11 @@ class Command {
                          self.collectDirs.append(contentsOf: [args[index + i]])
                          i += 1
                      }
+                 }
+             case "-l", "--logs":
+                 if let index = args.firstIndex(of: arg) {
+                     Self.options.insert(.unifiedLogs)
+                     Self.unifiedLogsFile = args[index + 1]
                  }
              case "-v", "--version":
                  print(version)
@@ -130,7 +137,7 @@ class Command {
              mainModule.log("Running Aftermath Version \(version)")
              mainModule.log("Aftermath Collection Started")
              mainModule.log("Collection started at \(mainModule.getCurrentTimeStandardized())")
-             mainModule.addTextToFile(atUrl: CaseFiles.metadataFile, text: "file,birth,modified,accessed,permissions,uid,gid, downloadedFrom")
+             mainModule.addTextToFile(atUrl: CaseFiles.metadataFile, text: "file,birth,modified,accessed,permissions,uid,gid,xattr,downloadedFrom")
              
 
              // System Recon
@@ -174,10 +181,9 @@ class Command {
              artifactModule.run()
              mainModule.log("Finished gathering artifacts")
 
-
              // Logs
              mainModule.log("Started logging unified logs")
-             let unifiedLogModule = UnifiedLogModule()
+             let unifiedLogModule = UnifiedLogModule(logFile: unifiedLogsFile)
              unifiedLogModule.run()
              mainModule.log("Finished logging unified logs")
              

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -243,6 +243,8 @@ class Command {
          print("--collect-dirs -> specify locations of (space-separated) directories to dump those raw files")
          print("    usage: --collect-dirs /Users/<USER>/Downloads /tmp")
          print("--deep -> performs deep scan and captures metadata from Users entire directory (WARNING: this may be time-consuming)")
+         print("--logs -> specify an external text file with unified log predicates to parse")
+         print("    usage: --logs /Users/<USER>/Desktop/myPredicates.txt")
          print("--pretty -> colorize Terminal output")
          print("--cleanup -> remove Aftermath Folders in default locations")
          exit(1)

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -115,12 +115,13 @@ class Command {
              if #available(macOS 12, *) {
                  let analysisModule = AnalysisModule(collectionDir: unzippedDir)
                  analysisModule.run()
+                 
+                 mainModule.log("Finished analysis module")
              } else {
-                 // Fallback on earlier versions
+                 mainModule.log("Aftermath requires macOS 12 or later in order to analyze collection data.")
+                 print("Aftermath requires macOS 12 or later in order to analyze collection data.")
              }
             
-             mainModule.log("Finished analysis module")
-             
              guard isDirectoryThatExists(path: Self.outputDir) else {
                  mainModule.log("Output directory is not a valid directory that exists")
                  return

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -129,6 +129,7 @@ class Command {
 
              // End Aftermath
              mainModule.log("Aftermath Finished")
+             exit(1)
          } else {
              CaseFiles.CreateCaseDir()
              let mainModule = AftermathModule()
@@ -192,6 +193,7 @@ class Command {
 
              // End Aftermath
              mainModule.log("Aftermath Finished")
+             exit(1)
          }
      }
 

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -129,7 +129,6 @@ class Command {
 
              // End Aftermath
              mainModule.log("Aftermath Finished")
-             exit(1)
          } else {
              CaseFiles.CreateCaseDir()
              let mainModule = AftermathModule()
@@ -193,7 +192,6 @@ class Command {
 
              // End Aftermath
              mainModule.log("Aftermath Finished")
-             exit(1)
          }
      }
 

--- a/aftermath/Module.swift
+++ b/aftermath/Module.swift
@@ -187,6 +187,7 @@ class AftermathModule {
         var birthTimestamp: String
         var lastModifiedTimestamp: String
         var lastAccessedTimestamp: String
+        var xattr: String = ""
         
         if fromFile.path.contains(",") {
             let sanitized = fromFile.path.replacingOccurrences(of: ",", with: " ")
@@ -202,8 +203,6 @@ class AftermathModule {
         } else {
             metadata.append("unknwon,")
         }
-        
-        
         
         if let lastModified = helpers.getFileLastModified(fromFile: fromFile) {
             lastModifiedTimestamp = Aftermath.dateFromEpochTimestamp(timeStamp: lastModified)
@@ -235,6 +234,18 @@ class AftermathModule {
             metadata.append("\(gid),")
         } else {
             metadata.append("unknown,")
+        }
+        
+        do {
+            let xattrs = try fromFile.listExtendedAttributes()
+            if xattrs.isEmpty {
+                xattr.append("none,")
+            } else { xattrs.forEach { xattr.append("\($0) ") } }
+            
+            metadata.append("\(xattr),")
+        } catch {
+            xattr.append("unknown,")
+            self.log("Unable to capture extended attributes for \(fromFile.path) due to error: \(error)")
         }
         
         if let mditem = MDItemCreate(nil, fromFile.path as CFString),

--- a/aftermath/Module.swift
+++ b/aftermath/Module.swift
@@ -256,7 +256,7 @@ class AftermathModule {
             if let downloadedFrom = mdattrs[kMDItemWhereFroms as String] {
                 if let downloadedArr = downloadedFrom as Any as? [String] {
                     for downloaded in downloadedArr {
-                        metadata.append("\(downloaded),")
+                        metadata.append("\(downloaded) ")
                     }
                 }
             }

--- a/analysis/Timeline.swift
+++ b/analysis/Timeline.swift
@@ -122,9 +122,10 @@ class Timeline: AftermathModule {
                 let permissions = columns[4]
                 let uid = columns[5]
                 let gid = columns[6]
-                let downloadedFrom = columns[7]
+                let xattr = columns[7]
+                let downloadedFrom = columns[8]
                 
-                let singleEntry = Metadata(file: filePath, birth: birth, modified: modified, accessed: accessed, permissions: permissions, uid: uid, gid: gid, downloadedFrom: downloadedFrom)
+                let singleEntry = Metadata(file: filePath, birth: birth, modified: modified, accessed: accessed, permissions: permissions, uid: uid, gid: gid, xattr: xattr, downloadedFrom: downloadedFrom)
                 metadata.append(singleEntry)
             }
         }
@@ -173,6 +174,7 @@ struct Metadata {
     var permissions: String
     var uid: String
     var gid: String
+    var xattr: String
     var downloadedFrom: String
 }
 

--- a/analysis/Timeline.swift
+++ b/analysis/Timeline.swift
@@ -114,7 +114,7 @@ class Timeline: AftermathModule {
         
         for row in rows {
             let columns = row.components(separatedBy: ",")
-            if columns.count == 8 {
+            if columns.count >= 8 {
                 let filePath = columns[0]
                 let birth = columns[1]
                 let modified = columns[2]

--- a/artifacts/ArtifactsModule.swift
+++ b/artifacts/ArtifactsModule.swift
@@ -34,5 +34,8 @@ class ArtifactsModule: AftermathModule, AMProto {
         
         let logFiles = LogFiles(logFilesDir: logFilesDir)
         logFiles.run()
+        
+        let configProfiles = ConfigurationProfiles()
+        configProfiles.run()
     }
 }

--- a/artifacts/ConfigurationProfiles.swift
+++ b/artifacts/ConfigurationProfiles.swift
@@ -1,0 +1,23 @@
+//
+//  ConfigurationProfiles.swift
+//  aftermath
+//
+//  Copyright  2022 JAMF Software, LLC
+//
+
+import Foundation
+
+class ConfigurationProfiles: ArtifactsModule {
+    
+    override func run() {
+        
+        self.log("Writing installed configuration profiles...")
+        
+        let outputFile = self.createNewCaseFile(dirUrl: moduleDirRoot, filename: "config_profiles.txt")
+            
+        let command = "sudo profiles list -all"
+        let output = Aftermath.shell("\(command)")
+        
+        self.addTextToFile(atUrl: outputFile, text: output)
+    }
+}

--- a/extensions/Data.swift
+++ b/extensions/Data.swift
@@ -9,6 +9,7 @@ import Foundation
 import CommonCrypto
 
 extension Data{
+    
     public func sha256() -> String{
         return hexStringFromData(input: digest(input: self as NSData))
     }

--- a/extensions/Data.swift
+++ b/extensions/Data.swift
@@ -1,0 +1,34 @@
+//
+//  Data.swift
+//  aftermath
+//
+//  Copyright  2022 JAMF Software, LLC
+//
+
+import Foundation
+import CommonCrypto
+
+extension Data{
+    public func sha256() -> String{
+        return hexStringFromData(input: digest(input: self as NSData))
+    }
+    
+    private func digest(input : NSData) -> NSData {
+        let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
+        var hash = [UInt8](repeating: 0, count: digestLength)
+        CC_SHA256(input.bytes, UInt32(input.length), &hash)
+        return NSData(bytes: hash, length: digestLength)
+    }
+    
+    private  func hexStringFromData(input: NSData) -> String {
+        var bytes = [UInt8](repeating: 0, count: input.length)
+        input.getBytes(&bytes, length: input.length)
+        
+        var hexString = ""
+        for byte in bytes {
+            hexString += String(format:"%02x", UInt8(byte))
+        }
+        
+        return hexString
+    }
+}

--- a/extensions/String.swift
+++ b/extensions/String.swift
@@ -1,0 +1,17 @@
+//
+//  String.swift
+//  aftermath
+//
+//  Copyright  2022 JAMF Software, LLC
+//
+
+import Foundation
+
+public extension String {
+    func sha256() -> String{
+        if let stringData = self.data(using: String.Encoding.utf8) {
+            return stringData.sha256()
+        }
+        return ""
+    }
+}

--- a/extensions/String.swift
+++ b/extensions/String.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public extension String {
+    
     func sha256() -> String{
         if let stringData = self.data(using: String.Encoding.utf8) {
             return stringData.sha256()

--- a/extensions/URL.swift
+++ b/extensions/URL.swift
@@ -1,0 +1,44 @@
+//
+//  URL.swift
+//  aftermath
+//
+//  Copyright  2022 JAMF Software, LLC
+//
+
+import Foundation
+
+extension URL {
+
+    // Get list of all extended attributes.
+    func listExtendedAttributes() throws -> [String] {
+
+        let list = try self.withUnsafeFileSystemRepresentation { fileSystemPath -> [String] in
+            let length = listxattr(fileSystemPath, nil, 0, 0)
+            guard length >= 0 else { throw URL.posixError(errno) }
+
+            // Create buffer with required size:
+            var namebuf = Array<CChar>(repeating: 0, count: length)
+
+            // Retrieve attribute list:
+            let result = listxattr(fileSystemPath, &namebuf, namebuf.count, 0)
+            guard result >= 0 else { throw URL.posixError(errno) }
+
+            // Extract attribute names:
+            let list = namebuf.split(separator: 0).compactMap {
+                $0.withUnsafeBufferPointer {
+                    $0.withMemoryRebound(to: UInt8.self) {
+                        String(bytes: $0, encoding: .utf8)
+                    }
+                }
+            }
+            return list
+        }
+        return list
+    }
+
+    // Helper function to create an NSError from a Unix errno.
+    private static func posixError(_ err: Int32) -> NSError {
+        return NSError(domain: NSPOSIXErrorDomain, code: Int(err),
+                       userInfo: [NSLocalizedDescriptionKey: String(cString: strerror(err))])
+    }
+}

--- a/persistence/LaunchItems.swift
+++ b/persistence/LaunchItems.swift
@@ -31,7 +31,7 @@ class LaunchItems: PersistenceModule {
                 let arr = binaryLocation as! [String]
                 binarySHA256 = collectBinaryHashInformation(binaryLocation: arr[0])
             } else {
-                self.log("Could not get plist information for \(url.relativeString)")
+                self.log("Could not get plist information for \(url.relativePath)")
             }
             
             // copy the plists to the persistence directory

--- a/persistence/LaunchItems.swift
+++ b/persistence/LaunchItems.swift
@@ -18,17 +18,49 @@ class LaunchItems: PersistenceModule {
     func captureLaunchData(urlLocations: [URL], capturedLaunchFile: URL) {
         for url in urlLocations {
             let plistDict = Aftermath.getPlistAsDict(atUrl: url)
+            var binaryName: String? = nil
+            var binarySHA256: String? = nil
+            
+            // get the progarm key and pass value to parser
+            if let binaryLocation = plistDict["Program"] {
+                binaryName = binaryLocation as? String
+                binarySHA256 = collectBinaryHashInformation(binaryLocation: binaryLocation as! String)
+            } else if let binaryLocation = plistDict["ProgramArguments"] {
+                // grab first element of ProgramArguments
+                binaryName = binaryLocation as? String
+                let arr = binaryLocation as! [String]
+                binarySHA256 = collectBinaryHashInformation(binaryLocation: arr[0])
+            } else {
+                self.log("Could not get plist information for \(url.relativeString)")
+            }
             
             // copy the plists to the persistence directory
             self.copyFileToCase(fileToCopy: url, toLocation: self.saveToRawDir)
             
             // write the plists to one file
             self.addTextToFile(atUrl: capturedLaunchFile, text: "\n----- \(url.path) -----\n")
+            self.addTextToFile(atUrl: capturedLaunchFile, text: "Binary Name: \(binaryName ?? "unknown")\n")
+            self.addTextToFile(atUrl: capturedLaunchFile, text: "Binary SHA256: \(binarySHA256 ?? "unknown")\n")
             self.addTextToFile(atUrl: capturedLaunchFile, text: plistDict.description)
         }
     }
     
-    override func run() {
+    private func collectBinaryHashInformation(binaryLocation: String)  -> String? { //throws
+        if filemanager.fileExists(atPath: binaryLocation) {
+            // convert to data
+            if let data = filemanager.contents(atPath: binaryLocation) {
+                // use extension to get sha256
+                let fileHash = data.sha256()
+                return fileHash
+            }
+        } else {
+            self.log("Binary does not exist at \(binaryLocation)")
+            return nil
+        }
+        return nil
+    }
+    
+    override func  run() {
         let launchDaemonsPath = "/Library/LaunchDaemons/"
         let launchAgentsPath = "/Library/LaunchAgents/"
         let capturedLaunchFile = self.createNewCaseFile(dirUrl: moduleDirRoot, filename: "launchItems.txt")


### PR DESCRIPTION
- collect extended attributes to metadata collection
- allow the input of an external text file for unified log filtering
- collect names of installed configuration profiles
- get hash info from binaries plists are pointing at if possible
- increased version number 
- resolved issue #48 (updated README)