### PR TITLE
Fix typos in browsers

### DIFF
--- a/filesystem/browsers/Chrome.swift
+++ b/filesystem/browsers/Chrome.swift
@@ -124,7 +124,7 @@ class Chrome: BrowserModule {
                 var file: URL
                 if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Google/Chrome/\(profile)/Preferences") {
                     file = URL(fileURLWithPath: "\(user.homedir)/Library/Application Support/Google/Chrome/\(profile)/Preferences")
-                    self.copyFileToCase(fileToCopy: file, toLocation: self.chromeDir, newFileName: "preferenes_\(user.username)_\(profile)")
+                    self.copyFileToCase(fileToCopy: file, toLocation: self.chromeDir, newFileName: "preferences_\(user.username)_\(profile)")
                 } else { continue }
                         
                 do {

--- a/filesystem/browsers/Chrome.swift
+++ b/filesystem/browsers/Chrome.swift
@@ -30,7 +30,7 @@ class Chrome: BrowserModule {
                 var file: URL
                 if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Google/Chrome/\(profile)/History") {
                     file = URL(fileURLWithPath: "\(user.homedir)/Library/Application Support/Google/Chrome/\(profile)/History")
-                    self.copyFileToCase(fileToCopy: file, toLocation: self.chromeDir, newFileName: "history_and_downloads\(user.username)_\(profile).db")
+                    self.copyFileToCase(fileToCopy: file, toLocation: self.chromeDir, newFileName: "history_and_downloads_\(user.username)_\(profile).db")
                 } else { continue }
 
                 // Open the history file

--- a/filesystem/browsers/Edge.swift
+++ b/filesystem/browsers/Edge.swift
@@ -30,7 +30,7 @@ class Edge: BrowserModule {
                 var file: URL
                 if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/History") {
                     file = URL(fileURLWithPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/History")
-                    self.copyFileToCase(fileToCopy: file, toLocation: self.edgeDir, newFileName: "history_and_downloads\(user.username)_\(profile).db")
+                    self.copyFileToCase(fileToCopy: file, toLocation: self.edgeDir, newFileName: "history_and_downloads_\(user.username)_\(profile).db")
                 } else { continue }
 
                 // Open the history file

--- a/filesystem/browsers/Edge.swift
+++ b/filesystem/browsers/Edge.swift
@@ -124,7 +124,7 @@ class Edge: BrowserModule {
                 var file: URL
                 if filemanager.fileExists(atPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/Preferences") {
                     file = URL(fileURLWithPath: "\(user.homedir)/Library/Application Support/Microsoft Edge/\(profile)/Preferences")
-                    self.copyFileToCase(fileToCopy: file, toLocation: self.edgeDir, newFileName: "preferenes_\(user.username)_\(profile)")
+                    self.copyFileToCase(fileToCopy: file, toLocation: self.edgeDir, newFileName: "preferences_\(user.username)_\(profile)")
                 } else { continue }
                         
                 do {


### PR DESCRIPTION
Fixes a typo in output file of browser preferences dumps. `preferenes` -> `preferences`

Also makes `history_and_downloads` have a separating `_`, like the other file dumps.