### PR TITLE
Fix issue when collecting launchd data

### DIFF
--- a/extensions/Collection.swift
+++ b/extensions/Collection.swift
@@ -1,0 +1,21 @@
+//
+//  Collection.swift
+//  aftermath
+//
+//  Created by Bart Reardon on 27/3/2024.
+//
+
+import Foundation
+
+public extension Collection {
+    
+    /// Returns: the pretty printed JSON string or an error string if any error occur.
+    var json: String {
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: self, options: [.prettyPrinted])
+            return String(data: jsonData, encoding: .utf8) ?? ""
+        } catch {
+            return "json serialization error: \(error)"
+        }
+    }
+}

--- a/persistence/LaunchItems.swift
+++ b/persistence/LaunchItems.swift
@@ -18,18 +18,23 @@ class LaunchItems: PersistenceModule {
     func captureLaunchData(urlLocations: [URL], capturedLaunchFile: URL) {
         for url in urlLocations {
             let plistDict = Aftermath.getPlistAsDict(atUrl: url)
-            var binaryName: String? = nil
-            var binarySHA256: String? = nil
+            var binaryName: String = ""
+            var binarySHA256: String = ""
             
             // get the progarm key and pass value to parser
             if let binaryLocation = plistDict["Program"] {
-                binaryName = binaryLocation as? String
-                binarySHA256 = collectBinaryHashInformation(binaryLocation: binaryLocation as! String)
+                binaryName = (binaryLocation as! String)
+                if let binarySHA256 = collectBinaryHashInformation(binaryLocation: binaryName) {
+                    self.log("Could not get binarySHA256 for \(binaryName)")
+                }
+                
             } else if let binaryLocation = plistDict["ProgramArguments"] {
                 // grab first element of ProgramArguments
-                binaryName = binaryLocation as? String
+                binaryName = (binaryLocation as! String)
                 let arr = binaryLocation as! [String]
-                binarySHA256 = collectBinaryHashInformation(binaryLocation: arr[0])
+                if let binarySHA256 = collectBinaryHashInformation(binaryLocation: arr[0]) {
+                    self.log("Could not get binarySHA256 for \(binaryName)")
+                }
             } else {
                 self.log("Could not get plist information for \(url.relativePath)")
             }
@@ -39,8 +44,8 @@ class LaunchItems: PersistenceModule {
             
             // write the plists to one file
             self.addTextToFile(atUrl: capturedLaunchFile, text: "\n----- \(url.path) -----\n")
-            self.addTextToFile(atUrl: capturedLaunchFile, text: "Binary Name: \(binaryName ?? "unknown")\n")
-            self.addTextToFile(atUrl: capturedLaunchFile, text: "Binary SHA256: \(binarySHA256 ?? "unknown")\n")
+            self.addTextToFile(atUrl: capturedLaunchFile, text: "Binary Name: \(binaryName)\n")
+            self.addTextToFile(atUrl: capturedLaunchFile, text: "Binary SHA256: \(binarySHA256)\n")
             self.addTextToFile(atUrl: capturedLaunchFile, text: plistDict.description)
         }
     }

--- a/persistence/LaunchItems.swift
+++ b/persistence/LaunchItems.swift
@@ -49,7 +49,7 @@ class LaunchItems: PersistenceModule {
             self.addTextToFile(atUrl: capturedLaunchFile, text: "\n----- \(url.path) -----\n")
             self.addTextToFile(atUrl: capturedLaunchFile, text: "Binary Name: \(binaryName)\n")
             self.addTextToFile(atUrl: capturedLaunchFile, text: "Binary SHA256: \(binarySHA256)\n")
-            self.addTextToFile(atUrl: capturedLaunchFile, text: plistDict.description)
+            self.addTextToFile(atUrl: capturedLaunchFile, text: plistDict.json)
         }
     }
     

--- a/persistence/LaunchItems.swift
+++ b/persistence/LaunchItems.swift
@@ -22,18 +22,21 @@ class LaunchItems: PersistenceModule {
             var binarySHA256: String = ""
             
             // get the progarm key and pass value to parser
-            if let binaryLocation = plistDict["Program"] {
-                binaryName = (binaryLocation as! String)
-                if let binarySHA256 = collectBinaryHashInformation(binaryLocation: binaryName) {
-                    self.log("Could not get binarySHA256 for \(binaryName)")
+            if let binaryLocation = plistDict["Program"] as? String {
+                binaryName = binaryLocation
+                if let SHA256 = collectBinaryHashInformation(binaryLocation: binaryLocation) {
+                    binarySHA256 = SHA256
+                } else {
+                    self.log("Could not get binarySHA256 for \(binaryLocation)")
                 }
                 
-            } else if let binaryLocation = plistDict["ProgramArguments"] {
+            } else if let binaryLocation = plistDict["ProgramArguments"] as? [String] {
                 // grab first element of ProgramArguments
-                binaryName = (binaryLocation as! String)
-                let arr = binaryLocation as! [String]
-                if let binarySHA256 = collectBinaryHashInformation(binaryLocation: arr[0]) {
-                    self.log("Could not get binarySHA256 for \(binaryName)")
+                binaryName = binaryLocation[0]
+                if let SHA256 = collectBinaryHashInformation(binaryLocation: binaryLocation[0]) {
+                    binarySHA256 = SHA256
+                } else {
+                    self.log("Could not get binarySHA256 for \(binaryLocation[0])")
                 }
             } else {
                 self.log("Could not get plist information for \(url.relativePath)")


### PR DESCRIPTION
Fix issue when collecting launchd data if a launchd item references a path that no longer exists.

this would previously cause an abort for trying to unwrap an optional

2.2.1 output

```
Could not cast value of type '__NSArrayM' (0x1f3f28d00) to 'NSString' (0x1f3f24ff0).
zsh: abort      sudo /usr/local/bin/aftermath
```

For example, a launchd item is created but the bundle/path it refers to is deleted then attempting to generate a sha for the path will fail. This PR updates the string variables so they aren't optionals and protects the attempt to generate a sha behind an `if let` with an appropriate log if the attempt fails.