### PR TITLE
Add provenance data collection support

### DIFF
--- a/aftermath.xcodeproj/project.pbxproj
+++ b/aftermath.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		A374535A275735B40074B65C /* LoginHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3745359275735B40074B65C /* LoginHooks.swift */; };
 		A374535D2757C1300074B65C /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A374535C2757C1300074B65C /* FileManager.swift */; };
 		A3CD4E56274434EE00869ECB /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CD4E55274434EE00869ECB /* Command.swift */; };
+		B7A4E38C2AD6EA3B00F380A8 /* ProvenanceTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A4E38B2AD6EA3B00F380A8 /* ProvenanceTracking.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -152,6 +153,7 @@
 		A3A3A3CD274754B400F8F557 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A3CD4E52274434EE00869ECB /* aftermath */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = aftermath; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3CD4E55274434EE00869ECB /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		B7A4E38B2AD6EA3B00F380A8 /* ProvenanceTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvenanceTracking.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -258,6 +260,7 @@
 				A08342D7284E48FC005E437A /* LogFiles.swift */,
 				5E494474293D50FE007FFBDD /* ConfigurationProfiles.swift */,
 				5EA438FE2A7010FF00F3E2B9 /* XProtectBehavioralService.swift */,
+				B7A4E38B2AD6EA3B00F380A8 /* ProvenanceTracking.swift */,
 			);
 			path = artifacts;
 			sourceTree = "<group>";
@@ -583,6 +586,7 @@
 				A0E1E3F6275ED2E4008D0DC6 /* NetworkModule.swift in Sources */,
 				A076742C27555FC100ED7066 /* PersistenceModule.swift in Sources */,
 				A0D6D54727FE147D002BB3C8 /* Overrides.swift in Sources */,
+				B7A4E38C2AD6EA3B00F380A8 /* ProvenanceTracking.swift in Sources */,
 				A0D6D54927FE52C1002BB3C8 /* SystemExtensions.swift in Sources */,
 				A08342D6284A8247005E437A /* AnalysisModule.swift in Sources */,
 				A029AB192876A29600649701 /* Pids.swift in Sources */,

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -169,7 +169,7 @@ class Command {
              mainModule.log("Running Aftermath Version \(version)")
              mainModule.log("Aftermath Collection Started")
              mainModule.log("Collection started at \(mainModule.getCurrentTimeStandardized())")
-             mainModule.addTextToFile(atUrl: CaseFiles.metadataFile, text: "file,birth,modified,accessed,permissions,uid,gid,xattr,downloadedFrom")
+             mainModule.addTextToFile(atUrl: CaseFiles.metadataFile, text: "file,birth,modified,accessed,permissions,uid,gid,xattr,downloadedFrom,provenance")
              
 
              // eslogger

--- a/aftermath/Module.swift
+++ b/aftermath/Module.swift
@@ -239,7 +239,7 @@ class AftermathModule {
         do {
             let xattrs = try fromFile.listExtendedAttributes()
             if xattrs.isEmpty {
-                xattr.append("none,")
+                xattr.append("none")
             } else { xattrs.forEach { xattr.append("\($0) ") } }
             
             metadata.append("\(xattr),")
@@ -258,11 +258,24 @@ class AftermathModule {
                     for downloaded in downloadedArr {
                         metadata.append("\(downloaded) ")
                     }
+                    metadata.append("none,")
+                } else {
+                    metadata.append("none,")
                 }
+            } else {
+                metadata.append("none,")
             }
                 
         } else {
             metadata.append("unknown,")
+        }
+
+        do {
+            let provenanceData = try fromFile.getExtendedAttribute(name: "com.apple.provenance")
+            let pkData = Data(provenanceData[3..<11])
+            metadata.append("\(pkData.withUnsafeBytes{$0.load(as: Int64.self)})")
+        } catch {
+            metadata.append("none")
         }
             
         self.addTextToFile(atUrl: CaseFiles.metadataFile, text: metadata)

--- a/artifacts/ArtifactsModule.swift
+++ b/artifacts/ArtifactsModule.swift
@@ -23,6 +23,7 @@ class ArtifactsModule: AftermathModule, AMProto {
         let profilesDir = self.createNewDir(dir: rawDir, dirname: "profiles")
         let logFilesDir = self.createNewDir(dir: rawDir, dirname: "logs")
         let xbsDir = self.createNewDir(dir: rawDir, dirname: "xbs")
+        let provenanceDir = self.createNewDir(dir: rawDir, dirname: "provenance")
         
         if Command.disableFeatures["databases"] == false {
             let tcc = TCC(tccDir: rawDir)
@@ -50,6 +51,10 @@ class ArtifactsModule: AftermathModule, AMProto {
             self.log("Collecting the XPdb")
             let xbs = XProtectBehavioralService(xbsDir: xbsDir)
             xbs.run()
+
+            self.log("Collecting the provenance database")
+            let prov = ProvenanceTracking(provenanceDir: provenanceDir)
+            prov.run()
         } else {
             self.log("Unable to capture XPdb due to unavailability on this OS")
         }

--- a/artifacts/ProvenanceTracking.swift
+++ b/artifacts/ProvenanceTracking.swift
@@ -1,0 +1,37 @@
+//
+//  ProvenanceTracking.swift
+//  aftermath
+//
+//  Created by Koh Nakagawa on 2023/10/11.
+//
+
+import Foundation
+
+@available(macOS 13, *)
+class ProvenanceTracking: ArtifactsModule {
+    let provenanceDir: URL
+
+    init(provenanceDir: URL) {
+        self.provenanceDir = provenanceDir
+    }
+
+    func collect() {
+        let execPolicy = URL(fileURLWithPath: "/var/db/SystemPolicyConfiguration/ExecPolicy")
+        let execPolicyShm = URL(fileURLWithPath: "/var/db/SystemPolicyConfiguration/ExecPolicy-shm")
+        let execPolicyWal = URL(fileURLWithPath: "/var/db/SystemPolicyConfiguration/ExecPolicy-wal")
+
+        if (filemanager.fileExists(atPath: execPolicy.path)) {
+            self.copyFileToCase(fileToCopy: execPolicy, toLocation: self.provenanceDir)
+        }
+        if (filemanager.fileExists(atPath: execPolicyShm.path)) {
+            self.copyFileToCase(fileToCopy: execPolicyShm, toLocation: self.provenanceDir)
+        }
+        if (filemanager.fileExists(atPath: execPolicyWal.path)) {
+            self.copyFileToCase(fileToCopy: execPolicyWal, toLocation: self.provenanceDir)
+        }
+    }
+
+    override func run() {
+        collect()
+    }
+}

--- a/extensions/URL.swift
+++ b/extensions/URL.swift
@@ -8,7 +8,22 @@
 import Foundation
 
 extension URL {
-
+    
+    func getExtendedAttribute(name: String) throws -> Data {
+        let data = try self.withUnsafeFileSystemRepresentation { fileSystemPath -> Data in
+            let length = getxattr(fileSystemPath, name, nil, 0, 0, 0)
+            guard length >= 0 else { throw URL.posixError(errno) }
+            
+            var data = Data(count: length)
+            let result =  data.withUnsafeMutableBytes { [count = data.count] in
+                getxattr(fileSystemPath, name, $0.baseAddress, count, 0, 0)
+            }
+            guard result >= 0 else { throw URL.posixError(errno) }
+            return data
+        }
+        return data
+    }
+    
     // Get list of all extended attributes.
     func listExtendedAttributes() throws -> [String] {
 


### PR DESCRIPTION
## Summary

This pull request adds support for collecting provenance extended attributes in Aftermath.  
Specifically, it introduces the following features:

- Collection of the `com.apple.provenance` extended attribute  
- Collection of data from the `provenance_tracking` table in the ExecPolicy file, which stores application information associated with the `com.apple.provenance` extended attribute  

Information about the provenance extended attribute is included in [my Black Hat presentation slides](https://i.blackhat.com/BH-USA-25/Presentations/USA-25-Koh-XUnprotect-Reverse-Engineering-macOS-XProtect-Remediator-V2.pdf). However, due to time constraints, only an overview is provided there. Below is a brief explanation of how the provenance extended attribute can be utilized.

## About the provenance extended attribute (introduced in macOS Ventura)

When an application is executed for the first time, **syspolicyd** assigns the provenance extended attribute (`com.apple.provenance`) to the application bundle and inserts application-related information (such as code signature and hash values) into the `provenance_tracking` table in the ExecPolicy database. This attribute is an 11-byte integer; the purpose of the first 3 bytes is currently unknown, while the remaining 8 bytes are random values.
The `pk` field in the `provenance_tracking` table corresponds to the 8-byte integer value of the `com.apple.provenance` attribute. For example:

```
CREATE TABLE provenance_tracking (  pk INTEGER PRIMARY KEY,  url TEXT NOT NULL,  bundle_id TEXT,  cdhash TEXT,  team_identifier TEXT,  signing_identifier TEXT,  flags INTEGER,  timestamp INTEGER NOT NULL,  link_pk INTEGER);
INSERT INTO provenance_tracking VALUES(-9131926598259274488,'/Applications/ChatGPT.app','com.openai.chat','a8f89be08e5bfff3ac2743df62052fb69eed660e','2DC432GLL2','com.openai.chat',2,1731488254,0);
```

In the example above, the `pk` value is `-9131926598259274488` (= `0x8144e12453d08d08`).  
The same value is assigned to the ChatGPT application bundle:

```
$ xattr -px "com.apple.provenance" /Applications/ChatGPT.app
01 02 00 08 8D D0 53 24 E1 44 81
```

When an application bundle with a provenance extended attribute is executed, the application runs inside the *provenance sandbox*. Any files created or modified[^1] by an application running in this sandbox inherit the same `com.apple.provenance` extended attribute as the application bundle. By checking the provenance extended attribute of a file and referencing the `provenance_tracking` table in ExecPolicy, it becomes possible to determine which application created or modified that file. I've created [a basic example demonstrating how to use the provenance attribute](https://github.com/FFRI/ShowProvenanceInfo). Please check it out as well.

This capability can be used, for example, to identify which application created a persistence-related plist file in `~/Library/LaunchAgents`.

Other potential use cases have also been identified (e.g., detecting the use of reflective loaders implemented with `NSCreateObjectFileImageFromMemory` and `NSLinkModule`).  
Further technical details will be included in the white paper for my Black Hat talk, which I plan to share here once available.

[^1]: Technically speaking, when file operations listed [here](https://github.com/FFRI/ProvenanceChecker) are performed, the provenance attribute is attached to the target file.